### PR TITLE
fix: codex MCPサーバーの引数をmcp-serverに修正

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
     "codex": {
       "type": "stdio",
       "command": "codex",
-      "args": ["mcp"]
+      "args": ["mcp-server"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- `codex mcp` → `codex mcp-server` に修正
- `codex mcp`はMCPサーバー管理用サブコマンド（list, add, remove等）
- `codex mcp-server`がMCPサーバーとして動作する正しいコマンド

## 動作確認
```bash
# mcp-server は MCP プロトコルに正常応答
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | codex mcp-server
{"id":1,"jsonrpc":"2.0","result":{"capabilities":{"tools":{"listChanged":true}},...}}

# mcp はサブコマンドが必要でサーバーとして動作しない
$ codex mcp
Usage: codex mcp [OPTIONS] <COMMAND>
Commands: list, get, add, remove, ...
```

## Test plan
- [x] `codex mcp --help` と `codex mcp-server --help` で違いを確認
- [x] `codex mcp-server` が MCP initialize に応答することを確認

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)