### PR TITLE
ci: add plugin manifest linting

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,24 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
+        with:
+          plugin_dir: "."


### PR DESCRIPTION
This adds a non-blocking metadata check so plugin-related changes are easier to review in CI.

It only adds one workflow file, uses read-only permissions, and leaves runtime code and release flow alone.

Why it looked like a fit here:

The workflow only checks the existing metadata surface already in the repo.
Permissions: read-only. No secrets. No publish. No runtime changes.

No runtime code or release flow changes are included here, and the workflow can be removed cleanly if it does not fit your setup.
If you would rather fold it into an existing workflow instead of a dedicated file, I can adjust the branch.